### PR TITLE
Fix GitHub Actions permissions for PR comments

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions permissions error when trying to comment on pull requests
- Added explicit permissions for `pull-requests: write` and `issues: write`

## Problem
The deploy-preview workflow was failing with:
```
RequestError [HttpError]: Resource not accessible by integration
```

This occurred when the workflow tried to create or update comments on pull requests.

## Solution
Added a `permissions` section to the workflow file to explicitly grant the necessary permissions:
```yaml
permissions:
  contents: read
  pull-requests: write
  issues: write
```

## Test plan
- [ ] This PR itself will test the fix when the deploy-preview workflow runs
- [ ] Verify that the workflow can successfully create/update comments
- [ ] Ensure no other permissions are affected

🤖 Generated with [Claude Code](https://claude.ai/code)