### PR TITLE
Show thinking indicator during processing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,9 @@ Bun.serve({
         const { session, workspace, text } = frame;
         console.log(`Processing prompt: "${text}" for session ${session}`);
         
+        /* NEW: notify client that Claude is thinking */
+        ws.send(JSON.stringify({ type: "thinking_delta" }));
+        
         // Create workspace directory
         mkdirSync(`./sandbox/${workspace}`, { recursive: true });
         
@@ -84,6 +87,9 @@ Bun.serve({
                         result: content 
                       } 
                     }));
+
+                    /* After providing the tool result, Claude will think again before responding — notify the client */
+                    ws.send(JSON.stringify({ type: "thinking_delta" }));
                   }
                 }
               } else if (msg.type === "result") {


### PR DESCRIPTION
Add "thinking..." indicators to the server to show when Claude is processing a prompt or between tool calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d21d6e8-a753-4fc3-84f1-4c816eeee8eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d21d6e8-a753-4fc3-84f1-4c816eeee8eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

