### PR TITLE
Fix messaging: Reset currentAssistantMessage on tool calls

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -39,6 +39,7 @@ function connect() {
 
   ws.addEventListener("message", e => {
     const m = JSON.parse(e.data);
+    console.log("Received WebSocket message:", m.type, m);
     
     switch(m.type) {
       case "assistant_text_delta":
@@ -84,6 +85,7 @@ function connect() {
           thinkingMessage.remove();
           thinkingMessage = null;
         }
+        currentAssistantMessage = null;
         break;
     }
   });

--- a/public/app.js
+++ b/public/app.js
@@ -64,6 +64,8 @@ function connect() {
         break;
         
       case "tool_call":
+        // Reset current assistant message so next text starts fresh
+        currentAssistantMessage = null;
         addToolMessage(m.tool.name, m.tool.args);
         break;
         


### PR DESCRIPTION
Fixes #19

When tool calls occurred, subsequent assistant text was being appended to the previous assistant message instead of creating new message blocks. This fix ensures each assistant response after tool calls gets its own message block.

Generated with [Claude Code](https://claude.ai/code)